### PR TITLE
Release 0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v2.1.2rc1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@v3.0-dk96-os
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v3.0-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@v2.1.2rc1-dk96-os
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,34 +1,42 @@
 # TreeScript Diff
-Find the differences between TreeScript files.
+Quickly, find the differences between two TreeScript files!
 
 ## Introduction
 A Command Line app for comparing TreeScript files, similar to `git diff`.
+- Both files must be correctly formatted TreeScript
+- Diff output options are provided
 
 ## Usage
 This package expects two input files, both must be valid TreeScript.
 
 ```bash
-treescript-diff <file1> <file2>
+treescript-diff [options] <file1> <file2>
 ```
 
 The first file is considered the original, the second file is updated TreeScript.
 
-### Default Action
-The program will return the diff in this structure:
-1. newly added files
+The program 
+
+### Default Diff Output
+The program will return the additions and removals in this structure:
+1. newly added files separated by newline character
 2. blank line
-3. deleted files
+3. removed files separated by newline character
 
 ### Additions Only
-Use the argument: `--added`
+To print only added files.
+
+Use the option: `--added` or `-a`
 
 ```bash
-treescript-diff <file1> <file2> --added
+treescript-diff -a <file1> <file2>
 ```
 
 ### Removals Only
-Use the argument: `--removed`
+To print only removed files.
+
+Use the option: `--removed` or `-r`
 
 ```bash
-treescript-diff <file1> <file2> --removed
+treescript-diff -r <file1> <file2>
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+"""Setup Package Configuration
+"""
+from setuptools import setup, find_packages
+
+
+setup(
+    name="treescript-diff",
+    version="0.1",
+    description="Determines the difference between two TreeScript files.",
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    author="DK96-OS",
+    url="https://github.com/DK96-OS/treescript-diff",
+    project_urls={
+        "Issues": "https://github.com/DK96-OS/treescript-diff/issues",
+        "Source Code": "https://github.com/DK96-OS/treescript-diff"
+    },
+    license="GPLv3",
+    packages=find_packages(exclude=['test']),
+    entry_points={
+        'console_scripts': [
+            'treescript-diff=treescript_diff.__main__:main',
+            'treescript_diff=treescript_diff.__main__:main',
+        ],
+    },
+    classifiers=[
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+    ],
+)


### PR DESCRIPTION
# TreeScript Diff v0.1 Release Notes

I am excited to announce the initial release of `treeScript-diff`! 

Now we can quickly find the differences between two TreeScript files!

## Features
- **Dual File Comparison**: Quickly compare two TreeScript files to find differences.
- **Customizable Outputs**: Control what differences to display:
  - **Additions**: New additions are listed as files.
  - **Removals**: Deletions from the first tree are displayed.
  - **Both**: (default) The tool displays additions followed by removals after a blank line.
  
## How to Use
To use TreeScript Diff, provide two TreeScript files as input. The program will output the differences:

```
treescript-diff [options] <file1> <file2>
```

### Options
- `--added` or `-a`: Show only additions.
- `--removed` or `-r`: Show only removals.

## Example
Here's a simple example to get you started:

```bash
treescript-diff example1.tree example2.tree
```

This will output the additions from `example2.tree` compared to `example1.tree` first, followed by any removals, each separated by a blank line.

### Additions Only
Suppose you are only interested in the files that were added:

```bash
treescript-diff -a example1.tree example2.tree
```

### Removals Only
If you want to know which files were removed:

```bash
treescript-diff -r example1.tree example2.tree
```