### PR TITLE
GitHub Workflows Debug Upload Coverage Report

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload Test Coverage Reports
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
+        if: always()
         with:
           name: treescript-diff-cov-${{ matrix.os }}-${{ matrix.python-version }}
           path: htmlcov/


### PR DESCRIPTION
Apply a correct method of ensuring coverage report artifacts are uploaded, specifically when coverage fails.