### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install runtime requirements
         run: python -m pip install -r requirements.txt
@@ -36,7 +36,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/
 
       - name: Sign Distributions
-        uses: dk96-os/gh-action-sigstore-python@v2.1.2rc1-dk96-os
+        uses: dk96-os/gh-action-sigstore-python@v3.1-dk96-os
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ setup(
         "Source Code": "https://github.com/DK96-OS/treescript-diff"
     },
     license="GPLv3",
-    packages=find_packages(exclude=['test']),
+    packages=find_packages(exclude=['test', 'test.*']),
+    install_requires=[
+        'treescript-files >= 0.2, < 0.3',
+    ],
     entry_points={
         'console_scripts': [
             'treescript-diff=treescript_diff.__main__:main',
@@ -34,5 +37,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="treescript-diff",
-    version="0.1",
+    version="0.1.1",
     description="Determines the difference between two TreeScript files.",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Build Improvements
- Python 3.13
- Upgrade Sigstore 2 -> 3
- Stop packaging tests with dists
- Install_requires on [treescript-files](https://github.com/DK96-OS/treescript-files)